### PR TITLE
fix some syntax char

### DIFF
--- a/galen.YAML-tmLanguage
+++ b/galen.YAML-tmLanguage
@@ -113,3 +113,6 @@ repository:
       end: (is|starts|ends|contains|matches)
       endCaptures:
         '1': {name: string.quoted.triple}
+    - name: support.function.galen
+      begin: (^\s*")
+      end: (")

--- a/galen.YAML-tmLanguage
+++ b/galen.YAML-tmLanguage
@@ -82,7 +82,7 @@ repository:
   group:
     patterns:
     - name: constant.language.galen
-      match: \s*&[-A-Za-z_]*
+      match: \s*&[-A-Za-z_0-9]*
 
   rule:
     patterns:
@@ -96,7 +96,7 @@ repository:
 
   test:
     patterns:
-    - match: \s*([-A-Za-z_\.]*)(:)
+    - match: \s*([-A-Za-z_\., 0-9\*]*)(:)
       captures:
         '1': {name: variable.parameter.galen}
         '2': {name: entity.name.function.galen}
@@ -106,13 +106,10 @@ repository:
     - name: string.quoted.triple
       captures:
         '1': {name: string.quoted.triple}
-      match: (near|below|above|left-of|right-of|
-              (contains|inside)( partly)?|on (top|bottom) (left|right)|
-              width\s|height\s|
-              text (is|contains|starts|ends|matches)|
-              aligned (vertically|horizontally) (all|top|right|left|bottom)?|
-              css .* (is|starts|ends|contains|matches)|
-              absent| visible|
-              centered (horizontally|vertically|all) (inside|on)|
-              component|color scheme|
-              )
+      match: (near|below|above|left-of|right-of|(contains|inside)( partly)?|on (top|bottom) (left|right)|^\s*(width) |^\s*(height) |text (is|contains|starts|ends|matches)|aligned (vertically|horizontally) (all|top|right|left|bottom)?|absent|visible|centered (horizontally|vertically|all) (inside|on)|component|color scheme)
+    - begin: (css)
+      beginCaptures:
+        '1': {name: string.quoted.triple}
+      end: (is|starts|ends|contains|matches)
+      endCaptures:
+        '1': {name: string.quoted.triple}

--- a/galen.tmLanguage
+++ b/galen.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -89,7 +89,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\s*&amp;[-A-Za-z_]*</string>
+					<string>\s*&amp;[-A-Za-z_0-9]*</string>
 					<key>name</key>
 					<string>constant.language.galen</string>
 				</dict>
@@ -278,9 +278,31 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(near|below|above|left-of|right-of| (contains|inside)( partly)?|on (top|bottom) (left|right)| width\s|height\s| text (is|contains|starts|ends|matches)| aligned (vertically|horizontally) (all|top|right|left|bottom)?| css .* (is|starts|ends|contains|matches)| absent| visible| centered (horizontally|vertically|all) (inside|on)| component|color scheme| )</string>
+					<string>(near|below|above|left-of|right-of|(contains|inside)( partly)?|on (top|bottom) (left|right)|^\s*(width) |^\s*(height) |text (is|contains|starts|ends|matches)|aligned (vertically|horizontally) (all|top|right|left|bottom)?|absent|visible|centered (horizontally|vertically|all) (inside|on)|component|color scheme)</string>
 					<key>name</key>
 					<string>string.quoted.triple</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(css)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>string.quoted.triple</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(is|starts|ends|contains|matches)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>string.quoted.triple</string>
+						</dict>
+					</dict>
 				</dict>
 			</array>
 		</dict>
@@ -303,7 +325,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\s*([-A-Za-z_\.]*)(:)</string>
+					<string>\s*([-A-Za-z_\., 0-9\*]*)(:)</string>
 				</dict>
 			</array>
 		</dict>

--- a/galen.tmLanguage
+++ b/galen.tmLanguage
@@ -269,14 +269,6 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>string.quoted.triple</string>
-						</dict>
-					</dict>
 					<key>match</key>
 					<string>(near|below|above|left-of|right-of|(contains|inside)( partly)?|on (top|bottom) (left|right)|^\s*(width) |^\s*(height) |text (is|contains|starts|ends|matches)|aligned (vertically|horizontally) (all|top|right|left|bottom)?|absent|visible|centered (horizontally|vertically|all) (inside|on)|component|color scheme)</string>
 					<key>name</key>
@@ -303,6 +295,14 @@
 							<string>string.quoted.triple</string>
 						</dict>
 					</dict>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(^\s*")</string>
+					<key>end</key>
+					<string>(")</string>
+					<key>name</key>
+					<string>support.function.galen</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
add numbers to group and test patterns
`&whitney_row11_content:`
add space, comma and \* to test patterns
`diary_container_text_text_hidden-*:`
`textSeparator_subtitle, title_text:`
joined in one line spec match ( multi-line broke on windows )
set width/height only to match at the start of line
separate css spec to bypass css-type highlight
`css font-size is "22px"`
